### PR TITLE
Exercise 3: attempt 1

### DIFF
--- a/typescript/resistor-color-duo/resistor-color-duo.ts
+++ b/typescript/resistor-color-duo/resistor-color-duo.ts
@@ -5,11 +5,15 @@
 // create a program that will take in the values of the bands and output numbers (so each
 // time i run, i will not need to remember the numbers.)
 
+// in ruby i'd... 
+
 // bands = { blah, blah, blah}
 // def decodedValue(band_1, band_2)
-//  return 
+//  return band_1 + band_2
 // end
-let bands = { 'black': 0, 'brown': 1, 'red': 2, 'orange': 3, 'yellow': 4, 'green': 5, 'blue': 6, 'violet': 7, 'grey': 8, 'white': 9}
 
-export function decodedValue(bands: any) {
+const bands = { 'black': 0, 'brown': 1, 'red': 2, 'orange': 3, 'yellow': 4, 'green': 5, 'blue': 6, 'violet': 7, 'grey': 8, 'white': 9}
+
+export function decodedValue(bands: any): string {
+  return `${bands}`
 };


### PR DESCRIPTION
Created `resistor-color-duo` directory

Completed: 
[x] Begin exercise 3
   [x] Pseudo-code process (in ruby)
   [x] Confirm TS params require `param: any` syntax to denote which data type the parameter will be.

Time Spent: 1 hour

To-Do:
- Complete exercise 3
  - How are the tests accessing the parameter? 
    - It seems to be showing the parameter as an array. Would setting a default of `bands = []` allow me to reference elements?